### PR TITLE
docs(flexbox): fix line highlight in wrap example

### DIFF
--- a/app/src/pages/docs/FlexboxPage.vue
+++ b/app/src/pages/docs/FlexboxPage.vue
@@ -162,7 +162,7 @@
 
                 <DemoCard
                     :code="flexboxWrapExampleRaw"
-                    highlight-lines="{4}"
+                    highlight-lines="{5}"
                 >
                     <FlexboxWrapExample/>
                 </DemoCard>


### PR DESCRIPTION
<!-- PR title should follow Conventional Commits: https://conventionalcommits.org -->

### Issue

<!-- Ссылка на issue (#123) -->

### Тип изменения

- [ ] feat
- [x] fix
- [ ] refactor
- [x] docs
- [ ] chore
- [ ] breaking change

### Описание

Исправлен номер подсвечиваемой строки в примере flexbox-wrap: было 4, стало 5.

### Breaking changes

<!-- Что изменилось в API -->

- Нет
