### PR TITLE
feat(table): add asChild prop to Table components

### DIFF
--- a/packages/core/src/table/Table.vue
+++ b/packages/core/src/table/Table.vue
@@ -1,5 +1,6 @@
 <template>
-    <table
+    <Primitive
+        as="table"
         :class="clsx(tableVariants({
             size,
             bigdata,
@@ -11,14 +12,15 @@
         v-bind="delegatedProps"
     >
         <slot/>
-    </table>
+    </Primitive>
 </template>
 
 <script lang="ts">
+import type { PrimitiveProps } from 'reka-ui'
 import type { HTMLAttributes } from 'vue'
 import type { TableVariants } from '.'
 
-export interface TableProps {
+export interface TableProps extends Omit<PrimitiveProps, 'as'> {
     class?: HTMLAttributes['class']
     size?: TableVariants['size']
     bigdata?: boolean
@@ -32,6 +34,7 @@ export interface TableProps {
 <script setup lang="ts">
 import { reactiveOmit } from '@vueuse/core'
 import { clsx } from 'clsx'
+import { Primitive } from 'reka-ui'
 import { tableVariants } from '.'
 
 const props = defineProps<TableProps>()

--- a/packages/core/src/table/TableCell.vue
+++ b/packages/core/src/table/TableCell.vue
@@ -1,5 +1,6 @@
 <template>
-    <td
+    <Primitive
+        as="td"
         :class="clsx(tableCellVariants({
             align,
             verticalAlign,
@@ -9,14 +10,15 @@
         v-bind="delegatedProps"
     >
         <slot/>
-    </td>
+    </Primitive>
 </template>
 
 <script lang="ts">
+import type { PrimitiveProps } from 'reka-ui'
 import type { HTMLAttributes } from 'vue'
 import type { TableCellVariants } from '@/table/index.ts'
 
-export interface TableCellProps {
+export interface TableCellProps extends Omit<PrimitiveProps, 'as'> {
     class?: HTMLAttributes['class']
     align?: TableCellVariants['align']
     verticalAlign?: TableCellVariants['verticalAlign']
@@ -28,6 +30,7 @@ export interface TableCellProps {
 <script setup lang="ts">
 import { reactiveOmit } from '@vueuse/core'
 import { clsx } from 'clsx'
+import { Primitive } from 'reka-ui'
 import { tableCellVariants } from '.'
 
 const props = defineProps<TableCellProps>()

--- a/packages/core/src/table/TableHead.vue
+++ b/packages/core/src/table/TableHead.vue
@@ -1,5 +1,6 @@
 <template>
-    <th
+    <Primitive
+        as="th"
         :class="clsx(tableHeadVariants({
             align,
             verticalAlign,
@@ -9,14 +10,15 @@
         v-bind="delegatedProps"
     >
         <slot/>
-    </th>
+    </Primitive>
 </template>
 
 <script lang="ts">
+import type { PrimitiveProps } from 'reka-ui'
 import type { HTMLAttributes } from 'vue'
 import type { TableHeadVariants } from '@/table/index.ts'
 
-export interface TableHeadProps {
+export interface TableHeadProps extends Omit<PrimitiveProps, 'as'> {
     class?: HTMLAttributes['class']
     align?: TableHeadVariants['align']
     verticalAlign?: TableHeadVariants['verticalAlign']
@@ -28,6 +30,7 @@ export interface TableHeadProps {
 <script setup lang="ts">
 import { reactiveOmit } from '@vueuse/core'
 import { clsx } from 'clsx'
+import { Primitive } from 'reka-ui'
 import { tableHeadVariants } from '.'
 
 const props = defineProps<TableHeadProps>()

--- a/packages/core/src/table/TableRow.vue
+++ b/packages/core/src/table/TableRow.vue
@@ -1,16 +1,18 @@
 <template>
-    <tr
+    <Primitive
+        as="tr"
         :class="clsx(tableRowVariants({ selected }), props.class)"
         v-bind="delegatedProps"
     >
         <slot/>
-    </tr>
+    </Primitive>
 </template>
 
 <script lang="ts">
+import type { PrimitiveProps } from 'reka-ui'
 import type { HTMLAttributes } from 'vue'
 
-export interface TableRowProps {
+export interface TableRowProps extends Omit<PrimitiveProps, 'as'> {
     class?: HTMLAttributes['class']
     selected?: boolean
 }
@@ -19,6 +21,7 @@ export interface TableRowProps {
 <script setup lang="ts">
 import { reactiveOmit } from '@vueuse/core'
 import { clsx } from 'clsx'
+import { Primitive } from 'reka-ui'
 import { tableRowVariants } from '.'
 
 const props = defineProps<TableRowProps>()


### PR DESCRIPTION
<!-- PR title should follow Conventional Commits: https://conventionalcommits.org -->

### Issue

Нет

### Тип изменения

- [x] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] breaking change

### Описание

Добавлен пропс `asChild` для компонентов `Table`, `TableCell`, `TableHead` и `TableRow`.

### Breaking changes

<!-- Что изменилось в API -->

- Нет
