### PR TITLE
feat(tabs): add asChild prop to Tabs components

### DIFF
--- a/packages/core/src/tabs/Tabs.vue
+++ b/packages/core/src/tabs/Tabs.vue
@@ -1,5 +1,6 @@
 <template>
-    <ul
+    <Primitive
+        as="ul"
         v-bind="delegatedProps"
         :class="clsx(tabsVariants({
             size,
@@ -9,14 +10,15 @@
         }), props.class)"
     >
         <slot/>
-    </ul>
+    </Primitive>
 </template>
 
 <script lang="ts">
+import type { PrimitiveProps } from 'reka-ui'
 import type { HTMLAttributes } from 'vue'
 import type { TabsVariants } from '.'
 
-export interface TabsProps {
+export interface TabsProps extends Omit<PrimitiveProps, 'as'> {
     class?: HTMLAttributes['class']
     size?: TabsVariants['size']
     borderedBottom?: boolean
@@ -28,6 +30,7 @@ export interface TabsProps {
 <script setup lang="ts">
 import { reactiveOmit } from '@vueuse/core'
 import { clsx } from 'clsx'
+import { Primitive } from 'reka-ui'
 import { tabsVariants } from '.'
 
 const props = defineProps<TabsProps>()

--- a/packages/core/src/tabs/TabsSection.vue
+++ b/packages/core/src/tabs/TabsSection.vue
@@ -1,16 +1,18 @@
 <template>
-    <li
+    <Primitive
+        as="li"
         :class="clsx(tabsSectionVariants({ selected }), props.class)"
         v-bind="delegatedProps"
     >
         <slot/>
-    </li>
+    </Primitive>
 </template>
 
 <script lang="ts">
+import type { PrimitiveProps } from 'reka-ui'
 import type { HTMLAttributes } from 'vue'
 
-export interface TabsSectionProps {
+export interface TabsSectionProps extends Omit<PrimitiveProps, 'as'> {
     class?: HTMLAttributes['class']
     selected?: boolean
 }
@@ -19,6 +21,7 @@ export interface TabsSectionProps {
 <script setup lang="ts">
 import { reactiveOmit } from '@vueuse/core'
 import { clsx } from 'clsx'
+import { Primitive } from 'reka-ui'
 import { tabsSectionVariants } from '.'
 
 const props = defineProps<TabsSectionProps>()


### PR DESCRIPTION
<!-- PR title should follow Conventional Commits: https://conventionalcommits.org -->

### Issue

Нет

### Тип изменения

- [x] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] breaking change

### Описание

Добавлен пропс asChild для компонентов `Tabs` и `TabsSection`.

### Breaking changes

<!-- Что изменилось в API -->

- Нет
