### PR TITLE
feat(thumbs): add asChild prop to Thumbs components

### DIFF
--- a/packages/core/src/thumbs/Thumbs.vue
+++ b/packages/core/src/thumbs/Thumbs.vue
@@ -1,17 +1,19 @@
 <template>
-    <ul
+    <Primitive
+        as="ul"
         v-bind="delegatedProps"
         :class="clsx(thumbsVariants({ size }), props.class)"
     >
         <slot/>
-    </ul>
+    </Primitive>
 </template>
 
 <script lang="ts">
+import type { PrimitiveProps } from 'reka-ui'
 import type { HTMLAttributes } from 'vue'
 import type { ThumbsVariants } from '.'
 
-export interface ThumbsProps {
+export interface ThumbsProps extends Omit<PrimitiveProps, 'as'> {
     class?: HTMLAttributes['class']
     size?: ThumbsVariants['size']
 }
@@ -20,6 +22,7 @@ export interface ThumbsProps {
 <script setup lang="ts">
 import { reactiveOmit } from '@vueuse/core'
 import { clsx } from 'clsx'
+import { Primitive } from 'reka-ui'
 import { thumbsVariants } from '.'
 
 const props = defineProps<ThumbsProps>()

--- a/packages/core/src/thumbs/ThumbsItem.vue
+++ b/packages/core/src/thumbs/ThumbsItem.vue
@@ -1,16 +1,18 @@
 <template>
-    <li
+    <Primitive
+        as="li"
         v-bind="delegatedProps"
         :class="clsx(thumbsItemVariants({ selected, shadowed, highlighted }), props.class)"
     >
         <slot/>
-    </li>
+    </Primitive>
 </template>
 
 <script lang="ts">
+import type { PrimitiveProps } from 'reka-ui'
 import type { HTMLAttributes } from 'vue'
 
-export interface ThumbsItemProps {
+export interface ThumbsItemProps extends Omit<PrimitiveProps, 'as'> {
     class?: HTMLAttributes['class']
     selected?: boolean
     shadowed?: boolean
@@ -21,6 +23,7 @@ export interface ThumbsItemProps {
 <script setup lang="ts">
 import { reactiveOmit } from '@vueuse/core'
 import { clsx } from 'clsx'
+import { Primitive } from 'reka-ui'
 import { thumbsItemVariants } from '.'
 
 const props = defineProps<ThumbsItemProps>()


### PR DESCRIPTION
<!-- PR title should follow Conventional Commits: https://conventionalcommits.org -->

### Issue

Нет

### Тип изменения

- [x] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] breaking change

### Описание

Добавлен пропс `asChild` для компонентов `Thumbs` и `ThumbsItem`.

### Breaking changes

<!-- Что изменилось в API -->

- Нет
